### PR TITLE
Fix: back to entrypoint in web to install dependencies

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,4 +3,4 @@ FROM node:17-alpine3.15
 COPY . /usr/src/web
 WORKDIR /usr/src/web
 
-CMD ["npm", "start"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,0 +1,4 @@
+#/bin/sh
+
+npm install
+npm start


### PR DESCRIPTION
My host doesn't have install any of the language implemented on the project. Just using docker volume, so the changing code is running only in the container (The process is explained on consecutive firsts commits on the README file).
So, for a fresh start, is necessary add _npm install_ to deploy.