### PR TITLE
Fix: latest action changes added to avoid node version warning

### DIFF
--- a/.github/workflows/pr-publish-tests.yaml
+++ b/.github/workflows/pr-publish-tests.yaml
@@ -92,7 +92,7 @@ jobs:
         run: docker-compose run -v "/$(pwd)/web:/usr/src/web"
           --entrypoint="npm test -- --coverage --watchAll=false" web
 
-      - uses: romeovs/lcov-reporter-action@v0.3.1
+      - uses: romeovs/lcov-reporter-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: web/coverage/lcov.info


### PR DESCRIPTION
Use latest changes in web coverage action to avoid node version warning.
The bump was commited in the repository but there is no release with this change yet, therefore, will use the `master` branch directly.