### PR TITLE
Feat: adding release creation with tag versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,14 @@
 name: publish-release
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - releases
 
 jobs:
   tag-and-release:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,6 +27,7 @@ jobs:
 
       - name: create release
         uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           body_path: ${{ github.workspace }}-CHANGELOG.txt
         env:


### PR DESCRIPTION
This is used to tag the latest commit(merge commit from `master` to `releases`) that will be use when creating the release in the same workflow.